### PR TITLE
:hammer: refactor: 포트폴리오 성과 주관기관 추가

### DIFF
--- a/src/main/java/com/cheeup/domain/portfolio/PortfolioAward.java
+++ b/src/main/java/com/cheeup/domain/portfolio/PortfolioAward.java
@@ -39,6 +39,9 @@ public class PortfolioAward {
     @Column(nullable = false, length = 30)
     private String grade;
 
+    @Column(nullable = true, length = 50)
+    String organization;
+
     @Column(nullable = false)
     private LocalDate earnedDate;
 

--- a/src/main/java/com/cheeup/domain/portfolio/PortfolioCertificate.java
+++ b/src/main/java/com/cheeup/domain/portfolio/PortfolioCertificate.java
@@ -40,6 +40,9 @@ public class PortfolioCertificate {
     @Column(length = 30)
     private String grade;
 
+    @Column(nullable = true, length = 50)
+    String organization;
+
     @Column(nullable = false)
     private LocalDate earnedDate;
 }

--- a/src/main/java/com/cheeup/domain/portfolio/PortfolioLanguage.java
+++ b/src/main/java/com/cheeup/domain/portfolio/PortfolioLanguage.java
@@ -39,6 +39,9 @@ public class PortfolioLanguage {
     @Column(nullable = false, length = 30)
     private String grade;
 
+    @Column(nullable = true, length = 50)
+    String organization;
+
     @Column(nullable = false)
     private LocalDate earnedDate;
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 [#51 포트폴리오 성과 엔티티 수정]

## 📄 개요
- 포트폴리오 성과에 주관기관 필드가 존재하지 않음

## 🔁 변경 사항
- 포트폴리오 성과 중 자격증, 어학, 수상내역 클래스에 주관기관 항목 추가

## 📸 스크린샷

![Screenshot 2025-01-04 at 11 34 55 AM](https://github.com/user-attachments/assets/ba8164ee-8280-4ff2-a235-beea79080ad3)

## 👀 기타 더 이야기해볼 점
- 논문 클래스의 경우 제출처가 있어 제외하고 주관기관을 추가하였는데 논문에 주관기관이 필요할지